### PR TITLE
refactor: Enable hook selector in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Modify your server/component-config.json to include this module:
     "pattern": [
       "*.find"
     ],
-    "relatedModels": true
+    "relatedModels": true,
+    "remoteModelRange": "after", // Default "before"
+    "remoteRelationRange": "before" // Default "before"
   },
 }
 ```
@@ -44,6 +46,14 @@ If no defaultLimit value is defined it will assume the maxLimit value.
 ### `maxLimit`: Integer
 
 Set the maximum value of the limit paramater on filter.
+
+### `remoteModelRange`: String
+
+Enables you to execute the function before or after a remote method is called by a client. Default 'before'.
+
+### `remoteRelationRange`: String
+
+Enables you to execute the function before or after a remote method is called by a client. Default 'before'.
 
 ## Tips
 

--- a/index.js
+++ b/index.js
@@ -81,13 +81,19 @@ module.exports = function(app, options) {
 
   const pattern = options &&
     Array.isArray(options.pattern) ? options.pattern : ['*.find'];
+
+  const hooks = ["before", "after"];
+  const {remoteModelRange = "before", remoteRelationRange = "before"} = options;
+  const modelRange = hooks.indexOf(remoteModelRange) !== -1 ? remoteModelRange : "before";
+  const relationRange = hooks.indexOf(remoteRelationRange) !== -1 ? remoteRelationRange : "before";
+
   for (let i = pattern.length - 1; i >= 0; i--) {
-    remotes.before(pattern[i], applyModelRange);
+    remotes[modelRange](pattern[i], applyModelRange);
   }
 
   const relatedModels = options &&
     options.relatedModels !== undefined ? options.relatedModels : true;
 
   if (relatedModels)
-    remotes.before('*.prototype.*', applyRelationRange);
+    remotes[relationRange]('*.prototype.*', applyRelationRange);
 };


### PR DESCRIPTION
- Enables you to execute the hook before or after a remote method is called by a client. Default 'before'.